### PR TITLE
Unable to answer a call on MIUI 12 issue fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-callkit",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Cordova plugin that lets you use iOS CallKit UI (with PushKit) and Android ConnectionService UI",
   "cordova": {
     "id": "cordova-plugin-callkit",

--- a/src/android/MyConnectionService.java
+++ b/src/android/MyConnectionService.java
@@ -188,6 +188,13 @@ public class MyConnectionService extends ConnectionService {
             }
 
             @Override
+            public void onAnswer(int videoState) { 
+                // called on Android 11 MIUI 12 instead of default onAnswer
+                Log.w(TAG, "[VOIPCALLKITPLUGIN] [MyConnectionService] [onCreateIncomingConnection] onAnswer(with videoState): CALLED. videoState: " + videoState);
+                onAnswer();
+            }
+
+            @Override
             public void onReject() {
                 //----------------------------------------------------------------------------------
                 //onReject / DECLINE CALL button


### PR DESCRIPTION
The reason why user couldn't answer a call on Android 11 MIUI 12 shell is that ConnectionService called overloaded onAnswer method that was not implemented in MyConnectionService.