### PR TITLE
exposed request permissions methods for ios

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-callkit",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Cordova plugin that lets you use iOS CallKit UI (with PushKit) and Android ConnectionService UI",
   "cordova": {
     "id": "cordova-plugin-callkit",

--- a/src/ios/CordovaCall.h
+++ b/src/ios/CordovaCall.h
@@ -37,6 +37,9 @@
 - (void)speakerOff:(CDVInvokedUrlCommand*)command;
 - (void)callNumber:(CDVInvokedUrlCommand*)command;
 - (void)reportCallEndedReason:(CDVInvokedUrlCommand*)command;
+- (void)reportCallEndedReason:(CDVInvokedUrlCommand*)command;
+- (void)requestMicPermission:(CDVInvokedUrlCommand*)command;
+- (void)requestCameraPermission:(CDVInvokedUrlCommand*)command;
 
 - (void)receiveCallFromRecents:(NSNotification *) notification;
 - (void)handleAudioRouteChange:(NSNotification *) notification;

--- a/src/ios/CordovaCall.h
+++ b/src/ios/CordovaCall.h
@@ -37,7 +37,6 @@
 - (void)speakerOff:(CDVInvokedUrlCommand*)command;
 - (void)callNumber:(CDVInvokedUrlCommand*)command;
 - (void)reportCallEndedReason:(CDVInvokedUrlCommand*)command;
-- (void)reportCallEndedReason:(CDVInvokedUrlCommand*)command;
 - (void)requestMicPermission:(CDVInvokedUrlCommand*)command;
 - (void)requestCameraPermission:(CDVInvokedUrlCommand*)command;
 

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -389,15 +389,15 @@ NSMutableDictionary* callsMetadata;
 
 - (void)requestMicPermission:(CDVInvokedUrlCommand*)command
 {
-    CDVPluginResult* pluginResult = nil;
+    __block CDVPluginResult* pluginResult = nil;
     NSLog(@"requesting mic permission");
     if ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio] == AVAuthorizationStatusNotDetermined) {
         [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler: ^ (BOOL granted)
             {
                 if (granted) {
-                    __block pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Record permission has been granted"];
+                    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Record permission has been granted"];
                 } else {
-                    __block pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Record permission has not been granted"];
+                    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Record permission has not been granted"];
             }
         }];
     }
@@ -407,15 +407,15 @@ NSMutableDictionary* callsMetadata;
 
 - (void)requestCameraPermission:(CDVInvokedUrlCommand*)command
 {
-    CDVPluginResult* pluginResult = nil;
+    __block CDVPluginResult* pluginResult = nil;
     NSLog(@"requesting camera permission");
     if ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo] == AVAuthorizationStatusNotDetermined) {
         [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler: ^ (BOOL granted)
             {
             if (granted) {
-                __block pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Camera permission has been granted"];
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Camera permission has been granted"];
             } else {
-                __block pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera permission has not been granted"];
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera permission has not been granted"];
             }
         }];
     }

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -388,6 +388,37 @@ NSMutableDictionary* callsMetadata;
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void)requestMicPermission:(CDVInvokedUrlCommand*)command
+{
+    CDVPluginResult* pluginResult = nil;
+
+    [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler: ^ (BOOL granted)
+        {
+        if (granted) {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Record permission has been granted"];
+        } else {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Record permission has not been granted"];
+    }
+    }];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void)requestCameraPermission:(CDVInvokedUrlCommand*)command
+{
+    CDVPluginResult* pluginResult = nil;
+
+    [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler: ^ (BOOL granted)
+        {
+        if (granted) {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Camera permission has been granted"];
+        } else {
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera permission has not been granted"];
+    }
+    }];
+    
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void)mute:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -391,10 +391,11 @@ NSMutableDictionary* callsMetadata;
 - (void)requestMicPermission:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;
-
+    NSLog(@"requesting mic permission");
     if ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio] == AVAuthorizationStatusNotDetermined) {
         [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler: ^ (BOOL granted)
             {
+                NSLog(@"permission request is granted: ", granted);
                 if (granted) {
                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Record permission has been granted"];
                 } else {
@@ -409,10 +410,11 @@ NSMutableDictionary* callsMetadata;
 - (void)requestCameraPermission:(CDVInvokedUrlCommand*)command
 {
     CDVPluginResult* pluginResult = nil;
-
+    NSLog(@"requesting camera permission");
     if ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo] == AVAuthorizationStatusNotDetermined) {
         [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler: ^ (BOOL granted)
             {
+            NSLog(@"permission request is granted: ", granted);
             if (granted) {
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Camera permission has been granted"];
             } else {

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -84,7 +84,6 @@ NSMutableDictionary* callsMetadata;
     
     self.callController = [[CXCallController alloc] init];
     callsMetadata = [[NSMutableDictionary alloc]initWithCapacity:5];
-    [self requestMicPermission]
     
     //allows user to make call from recents
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(receiveCallFromRecents:) name:@"RecentsCallNotification" object:nil];
@@ -395,7 +394,6 @@ NSMutableDictionary* callsMetadata;
     if ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio] == AVAuthorizationStatusNotDetermined) {
         [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler: ^ (BOOL granted)
             {
-                NSLog(@"permission request is granted: ", granted);
                 if (granted) {
                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Record permission has been granted"];
                 } else {
@@ -414,7 +412,6 @@ NSMutableDictionary* callsMetadata;
     if ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo] == AVAuthorizationStatusNotDetermined) {
         [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler: ^ (BOOL granted)
             {
-            NSLog(@"permission request is granted: ", granted);
             if (granted) {
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Camera permission has been granted"];
             } else {

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -84,7 +84,7 @@ NSMutableDictionary* callsMetadata;
     
     self.callController = [[CXCallController alloc] init];
     callsMetadata = [[NSMutableDictionary alloc]initWithCapacity:5];
-    
+    [self requestMicPermission]
     
     //allows user to make call from recents
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(receiveCallFromRecents:) name:@"RecentsCallNotification" object:nil];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -392,14 +392,17 @@ NSMutableDictionary* callsMetadata;
 {
     CDVPluginResult* pluginResult = nil;
 
-    [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler: ^ (BOOL granted)
-        {
-        if (granted) {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Record permission has been granted"];
-        } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Record permission has not been granted"];
+    if ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio] == AVAuthorizationStatusNotDetermined) {
+        [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler: ^ (BOOL granted)
+            {
+                if (granted) {
+                    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Record permission has been granted"];
+                } else {
+                    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Record permission has not been granted"];
+            }
+        }];
     }
-    }];
+
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
@@ -407,14 +410,16 @@ NSMutableDictionary* callsMetadata;
 {
     CDVPluginResult* pluginResult = nil;
 
-    [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler: ^ (BOOL granted)
-        {
-        if (granted) {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Camera permission has been granted"];
-        } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera permission has not been granted"];
+    if ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo] == AVAuthorizationStatusNotDetermined) {
+        [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler: ^ (BOOL granted)
+            {
+            if (granted) {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Camera permission has been granted"];
+            } else {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera permission has not been granted"];
+            }
+        }];
     }
-    }];
     
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -386,12 +386,18 @@ NSMutableDictionary* callsMetadata;
     
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
-
 - (void)requestMicPermission:(CDVInvokedUrlCommand*)command
 {
     __block CDVPluginResult* pluginResult = nil;
     NSLog(@"requesting mic permission");
-    if ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio] == AVAuthorizationStatusNotDetermined) {
+    switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio]) {
+        case AVAuthorizationStatusAuthorized:
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Record permission has been granted"];
+        break;
+        case AVAuthorizationStatusDenied:
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Record permission has not been granted"];
+        break;
+        case AVAuthorizationStatusNotDetermined:
         [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler: ^ (BOOL granted)
             {
                 if (granted) {
@@ -400,6 +406,7 @@ NSMutableDictionary* callsMetadata;
                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Record permission has not been granted"];
             }
         }];
+        break;
     }
 
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -409,15 +416,23 @@ NSMutableDictionary* callsMetadata;
 {
     __block CDVPluginResult* pluginResult = nil;
     NSLog(@"requesting camera permission");
-    if ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo] == AVAuthorizationStatusNotDetermined) {
+    switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo]) {
+        case AVAuthorizationStatusAuthorized:
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Camera permission has been granted"];
+        break;
+        case AVAuthorizationStatusDenied:
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera permission has not been granted"];
+        break;
+        case AVAuthorizationStatusNotDetermined:
         [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler: ^ (BOOL granted)
             {
-            if (granted) {
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Camera permission has been granted"];
-            } else {
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera permission has not been granted"];
+                if (granted) {
+                    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Camera permission has been granted"];
+                } else {
+                    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera permission has not been granted"];
             }
         }];
+        break;
     }
     
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -401,6 +401,7 @@ NSMutableDictionary* callsMetadata;
         [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler: ^ (BOOL granted)
             {
                 if (granted) {
+                    NSLog(@"mic permission granted");
                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Record permission has been granted"];
                 } else {
                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Record permission has not been granted"];
@@ -427,6 +428,7 @@ NSMutableDictionary* callsMetadata;
         [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler: ^ (BOOL granted)
             {
                 if (granted) {
+                    NSLog(@"camera permission granted");
                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Camera permission has been granted"];
                 } else {
                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera permission has not been granted"];

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -395,9 +395,9 @@ NSMutableDictionary* callsMetadata;
         [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler: ^ (BOOL granted)
             {
                 if (granted) {
-                    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Record permission has been granted"];
+                    __block pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Record permission has been granted"];
                 } else {
-                    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Record permission has not been granted"];
+                    __block pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Record permission has not been granted"];
             }
         }];
     }
@@ -413,9 +413,9 @@ NSMutableDictionary* callsMetadata;
         [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler: ^ (BOOL granted)
             {
             if (granted) {
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Camera permission has been granted"];
+                __block pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Camera permission has been granted"];
             } else {
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera permission has not been granted"];
+                __block pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera permission has not been granted"];
             }
         }];
     }

--- a/src/ios/CordovaCall.m
+++ b/src/ios/CordovaCall.m
@@ -386,59 +386,63 @@ NSMutableDictionary* callsMetadata;
     
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
+
 - (void)requestMicPermission:(CDVInvokedUrlCommand*)command
 {
     __block CDVPluginResult* pluginResult = nil;
-    NSLog(@"requesting mic permission");
-    switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio]) {
+    AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
+    switch (status) {
         case AVAuthorizationStatusAuthorized:
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Record permission has been granted"];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         break;
         case AVAuthorizationStatusDenied:
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Record permission has not been granted"];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         break;
         case AVAuthorizationStatusNotDetermined:
         [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler: ^ (BOOL granted)
             {
                 if (granted) {
-                    NSLog(@"mic permission granted");
                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Record permission has been granted"];
                 } else {
                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Record permission has not been granted"];
             }
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         }];
         break;
     }
-
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void)requestCameraPermission:(CDVInvokedUrlCommand*)command
 {
     __block CDVPluginResult* pluginResult = nil;
-    NSLog(@"requesting camera permission");
-    switch ([AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo]) {
+    AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
+    switch (status) {
         case AVAuthorizationStatusAuthorized:
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Camera permission has been granted"];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         break;
         case AVAuthorizationStatusDenied:
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera permission has not been granted"];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         break;
         case AVAuthorizationStatusNotDetermined:
         [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler: ^ (BOOL granted)
             {
-                if (granted) {
-                    NSLog(@"camera permission granted");
-                    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Camera permission has been granted"];
-                } else {
-                    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera permission has not been granted"];
-            }
+            dispatch_async(dispatch_get_main_queue(), ^{
+                    if (granted) {
+                        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"Camera permission has been granted"];
+                    } else {
+                        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Camera permission has not been granted"];
+                }
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+            });
         }];
         break;
     }
-    
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
+
 
 - (void)mute:(CDVInvokedUrlCommand*)command
 {

--- a/src/js/CordovaCall.js
+++ b/src/js/CordovaCall.js
@@ -123,3 +123,11 @@ exports.callNumber = function(to, success, error) {
 exports.reportCallEndedReason = function (callId, reason, success, error) {
     exec(success, error, "CordovaCall", "reportCallEndedReason", [callId, reason]);
 }
+
+exports.requestMicPermission = function(success, error) {
+    exec(success, error, "CordovaCall", "requestMicPermission", []);
+};
+
+exports.requestCameraPermission = function(success, error) {
+    exec(success, error, "CordovaCall", "requestCameraPermission", []);
+};

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -158,3 +158,11 @@ exports.callNumber = function (to, success, error) {
 exports.reportCallEndedReason = function (callId, reason, success, error) {
   exec(success, error, "CordovaCall", "reportCallEndedReason", [callId, reason]);
 };
+
+exports.requestMicPermission = function (success, error) {
+  exec(success, error, "CordovaCall", "requestMicPermission");
+};
+
+exports.requestCameraPermission = function (success, error) {
+  exec(success, error, "CordovaCall", "requestCameraPermission");
+};

--- a/www/CordovaCall.js
+++ b/www/CordovaCall.js
@@ -160,9 +160,9 @@ exports.reportCallEndedReason = function (callId, reason, success, error) {
 };
 
 exports.requestMicPermission = function (success, error) {
-  exec(success, error, "CordovaCall", "requestMicPermission");
+  exec(success, error, "CordovaCall", "requestMicPermission", []);
 };
 
 exports.requestCameraPermission = function (success, error) {
-  exec(success, error, "CordovaCall", "requestCameraPermission");
+  exec(success, error, "CordovaCall", "requestCameraPermission", []);
 };


### PR DESCRIPTION
This PR adds requestMicPermission and requestCameraPermission methods to invoke in mobile app. Please note that completion handler for the requestCameraPermission is invoked on main thread to prevent twilio UI to be opened.